### PR TITLE
feat: HTLCクレームコマンドの実装

### DIFF
--- a/fusion-cli/Cargo.toml
+++ b/fusion-cli/Cargo.toml
@@ -16,3 +16,8 @@ tokio = { version = "1.0", features = ["full"] }
 anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+chrono = { version = "0.4", features = ["serde"] }
+
+[dev-dependencies]
+assert_cmd = "2.0"
+predicates = "3.0"

--- a/fusion-cli/tests/cli_tests.rs
+++ b/fusion-cli/tests/cli_tests.rs
@@ -1,0 +1,145 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serde_json::{json, Value};
+
+#[test]
+fn test_claim_with_valid_secret() {
+    // Create HTLC first
+    let mut cmd = Command::cargo_bin("fusion-cli").unwrap();
+    let output = cmd
+        .args(&[
+            "create-htlc",
+            "--sender", "Alice",
+            "--recipient", "Bob",
+            "--amount", "1000",
+            "--timeout", "3600"
+        ])
+        .output()
+        .unwrap();
+    
+    assert!(output.status.success());
+    let create_response: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let htlc_id = create_response["htlc_id"].as_str().unwrap();
+    let secret = create_response["secret"].as_str().unwrap();
+    
+    // Test claim with valid secret
+    let mut cmd = Command::cargo_bin("fusion-cli").unwrap();
+    let output = cmd
+        .args(&[
+            "claim",
+            "--htlc-id", htlc_id,
+            "--secret", secret
+        ])
+        .output()
+        .unwrap();
+    
+    assert!(output.status.success());
+    let claim_response: Value = serde_json::from_slice(&output.stdout).unwrap();
+    
+    assert_eq!(claim_response["htlc_id"], htlc_id);
+    assert_eq!(claim_response["status"], "Claimed");
+    assert!(claim_response["claimed_at"].is_string());
+}
+
+#[test]
+fn test_claim_with_invalid_secret() {
+    // Create HTLC first
+    let mut cmd = Command::cargo_bin("fusion-cli").unwrap();
+    let output = cmd
+        .args(&[
+            "create-htlc",
+            "--sender", "Alice",
+            "--recipient", "Bob",
+            "--amount", "1000",
+            "--timeout", "3600"
+        ])
+        .output()
+        .unwrap();
+    
+    assert!(output.status.success());
+    let create_response: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let htlc_id = create_response["htlc_id"].as_str().unwrap();
+    
+    // Test claim with wrong secret
+    let mut cmd = Command::cargo_bin("fusion-cli").unwrap();
+    let output = cmd
+        .args(&[
+            "claim",
+            "--htlc-id", htlc_id,
+            "--secret", "0000000000000000000000000000000000000000000000000000000000000000"
+        ])
+        .output()
+        .unwrap();
+    
+    // Should fail
+    assert!(!output.status.success());
+    let error_response: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(error_response["error"].as_str().unwrap().contains("Invalid secret"));
+}
+
+#[test]
+fn test_claim_nonexistent_htlc() {
+    let mut cmd = Command::cargo_bin("fusion-cli").unwrap();
+    let output = cmd
+        .args(&[
+            "claim",
+            "--htlc-id", "nonexistent_htlc",
+            "--secret", "0000000000000000000000000000000000000000000000000000000000000000"
+        ])
+        .output()
+        .unwrap();
+    
+    // Should fail
+    assert!(!output.status.success());
+    let error_response: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(error_response["error"].as_str().unwrap().contains("HTLC not found"));
+}
+
+#[test]
+fn test_claim_already_claimed() {
+    // Create HTLC first
+    let mut cmd = Command::cargo_bin("fusion-cli").unwrap();
+    let output = cmd
+        .args(&[
+            "create-htlc",
+            "--sender", "Alice",
+            "--recipient", "Bob",
+            "--amount", "1000",
+            "--timeout", "3600"
+        ])
+        .output()
+        .unwrap();
+    
+    assert!(output.status.success());
+    let create_response: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let htlc_id = create_response["htlc_id"].as_str().unwrap();
+    let secret = create_response["secret"].as_str().unwrap();
+    
+    // First claim should succeed
+    let mut cmd = Command::cargo_bin("fusion-cli").unwrap();
+    let output = cmd
+        .args(&[
+            "claim",
+            "--htlc-id", htlc_id,
+            "--secret", secret
+        ])
+        .output()
+        .unwrap();
+    
+    assert!(output.status.success());
+    
+    // Second claim should fail
+    let mut cmd = Command::cargo_bin("fusion-cli").unwrap();
+    let output = cmd
+        .args(&[
+            "claim",
+            "--htlc-id", htlc_id,
+            "--secret", secret
+        ])
+        .output()
+        .unwrap();
+    
+    assert!(!output.status.success());
+    let error_response: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(error_response["error"].as_str().unwrap().contains("already claimed"));
+}

--- a/fusion-core/Cargo.toml
+++ b/fusion-core/Cargo.toml
@@ -16,6 +16,9 @@ rand.workspace = true
 subtle.workspace = true
 ethers = { version = "2.0", features = ["ws", "rustls"] }
 tokio = { workspace = true, features = ["full"] }
+dirs = "5.0"
+anyhow = "1.0"
+serde_json = "1.0"
 
 [dev-dependencies]
 tokio.workspace = true

--- a/fusion-core/src/lib.rs
+++ b/fusion-core/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod chains;
 pub mod config;
 pub mod htlc;
+pub mod storage;

--- a/fusion-core/src/storage.rs
+++ b/fusion-core/src/storage.rs
@@ -1,0 +1,99 @@
+use crate::htlc::{Htlc, SecretHash};
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::{Duration, SystemTime};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct StoredHtlc {
+    pub id: String,
+    pub sender: String,
+    pub recipient: String,
+    pub amount: u64,
+    pub secret_hash: SecretHash,
+    pub timeout_seconds: u64,
+    pub created_at: SystemTime,
+    pub state: String,
+    pub claimed_at: Option<SystemTime>,
+}
+
+pub struct HtlcStorage {
+    storage_path: PathBuf,
+    htlcs: Arc<Mutex<HashMap<String, StoredHtlc>>>,
+}
+
+impl HtlcStorage {
+    pub fn new() -> Result<Self> {
+        let storage_path = dirs::data_dir()
+            .context("Failed to get data directory")?
+            .join("fusion-cli")
+            .join("htlcs.json");
+        
+        // Create directory if it doesn't exist
+        if let Some(parent) = storage_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        
+        let mut storage = Self {
+            storage_path,
+            htlcs: Arc::new(Mutex::new(HashMap::new())),
+        };
+        
+        storage.load()?;
+        Ok(storage)
+    }
+    
+    fn load(&mut self) -> Result<()> {
+        if self.storage_path.exists() {
+            let data = fs::read_to_string(&self.storage_path)?;
+            let htlcs: HashMap<String, StoredHtlc> = serde_json::from_str(&data)?;
+            *self.htlcs.lock().unwrap() = htlcs;
+        }
+        Ok(())
+    }
+    
+    fn save(&self) -> Result<()> {
+        let htlcs = self.htlcs.lock().unwrap();
+        let data = serde_json::to_string_pretty(&*htlcs)?;
+        fs::write(&self.storage_path, data)?;
+        Ok(())
+    }
+    
+    pub fn store_htlc(&self, id: String, htlc: &Htlc, timeout_seconds: u64) -> Result<()> {
+        let stored_htlc = StoredHtlc {
+            id: id.clone(),
+            sender: htlc.sender().to_string(),
+            recipient: htlc.recipient().to_string(),
+            amount: htlc.amount(),
+            secret_hash: *htlc.secret_hash(),
+            timeout_seconds,
+            created_at: SystemTime::now(),
+            state: format!("{:?}", htlc.state()),
+            claimed_at: None,
+        };
+        
+        self.htlcs.lock().unwrap().insert(id, stored_htlc);
+        self.save()?;
+        Ok(())
+    }
+    
+    pub fn get_htlc(&self, id: &str) -> Result<Option<StoredHtlc>> {
+        let htlcs = self.htlcs.lock().unwrap();
+        Ok(htlcs.get(id).cloned())
+    }
+    
+    pub fn update_htlc_state(&self, id: &str, state: &str, claimed_at: Option<SystemTime>) -> Result<()> {
+        let mut htlcs = self.htlcs.lock().unwrap();
+        if let Some(htlc) = htlcs.get_mut(id) {
+            htlc.state = state.to_string();
+            htlc.claimed_at = claimed_at;
+        }
+        drop(htlcs);
+        self.save()?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
Closes #16

## 概要
HTLCをクレームするCLIコマンドを実装しました。

## 変更内容
- HTLCのストレージ機能を追加（ファイルベース）
- `fusion-cli claim` コマンドの実装
- エラーハンドリングの実装
- CLIコマンドのintegrationテストを追加

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent storage for HTLCs, enabling saving, retrieval, and state updates across CLI sessions.
  * Implemented full claim functionality, including validation and state management, with detailed error handling and user feedback.
* **Bug Fixes**
  * Improved error messages for invalid claim attempts, non-existent HTLCs, and already claimed contracts.
* **Tests**
  * Introduced comprehensive integration tests for HTLC creation and claim operations, covering success and error scenarios.
* **Documentation**
  * Updated public API to expose storage capabilities for external use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->