### PR TITLE
feat: HTLCクレームコマンドの実装

### DIFF
--- a/fusion-cli/Cargo.toml
+++ b/fusion-cli/Cargo.toml
@@ -18,3 +18,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 once_cell = "1.19"
 chrono = { version = "0.4", features = ["serde"] }
+
+[dev-dependencies]
+assert_cmd = "2.0"
+predicates = "3.0"

--- a/fusion-cli/examples/claim_example.rs
+++ b/fusion-cli/examples/claim_example.rs
@@ -1,0 +1,48 @@
+//! Example of using the claim command
+//! 
+//! This example demonstrates how to create an HTLC and then claim it using the correct secret.
+
+use std::process::Command;
+use serde_json::Value;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("Creating HTLC...");
+    
+    // Create an HTLC
+    let output = Command::new("cargo")
+        .args(&["run", "--", "create-htlc", "--sender", "Alice", "--recipient", "Bob", "--amount", "1000"])
+        .output()?;
+    
+    if !output.status.success() {
+        eprintln!("Failed to create HTLC: {}", String::from_utf8_lossy(&output.stderr));
+        return Ok(());
+    }
+    
+    // Parse the output
+    let output_str = String::from_utf8(output.stdout)?;
+    let json: Value = serde_json::from_str(&output_str)?;
+    
+    let htlc_id = json["htlc_id"].as_str().unwrap();
+    let secret = json["secret"].as_str().unwrap();
+    
+    println!("Created HTLC with ID: {}", htlc_id);
+    println!("Secret: {}", secret);
+    println!("\nClaiming HTLC...");
+    
+    // Claim the HTLC
+    let claim_output = Command::new("cargo")
+        .args(&["run", "--", "claim", "--htlc-id", htlc_id, "--secret", secret])
+        .output()?;
+    
+    if !claim_output.status.success() {
+        eprintln!("Failed to claim HTLC: {}", String::from_utf8_lossy(&claim_output.stderr));
+        return Ok(());
+    }
+    
+    let claim_str = String::from_utf8(claim_output.stdout)?;
+    let claim_json: Value = serde_json::from_str(&claim_str)?;
+    
+    println!("Claim result: {}", serde_json::to_string_pretty(&claim_json)?);
+    
+    Ok(())
+}

--- a/fusion-cli/src/main.rs
+++ b/fusion-cli/src/main.rs
@@ -119,16 +119,109 @@ async fn handle_create_htlc(args: CreateHtlcArgs) -> Result<()> {
     Ok(())
 }
 
-async fn handle_claim(_args: ClaimArgs) -> Result<()> {
-    // TODO: Implement claim logic
-    // For now, return a placeholder response
-    let output = json!({
-        "error": "Claim functionality not yet implemented",
-        "message": "This feature will be implemented in Issue #16"
-    });
+async fn handle_claim(args: ClaimArgs) -> Result<()> {
+    // Get HTLC from storage
+    let stored_htlc = match STORAGE.get(&args.htlc_id) {
+        Ok(htlc) => htlc,
+        Err(_) => {
+            let output = json!({
+                "error": "HTLC not found",
+                "htlc_id": args.htlc_id
+            });
+            println!("{}", serde_json::to_string_pretty(&output)?);
+            return Ok(());
+        }
+    };
 
-    println!("{}", serde_json::to_string_pretty(&output)?);
-    Ok(())
+    // Check if HTLC is already claimed
+    if stored_htlc.state == HtlcState::Claimed {
+        let output = json!({
+            "error": "HTLC already claimed",
+            "htlc_id": args.htlc_id,
+            "status": stored_htlc.state
+        });
+        println!("{}", serde_json::to_string_pretty(&output)?);
+        return Ok(());
+    }
+
+    // Check if HTLC is refunded
+    if stored_htlc.state == HtlcState::Refunded {
+        let output = json!({
+            "error": "HTLC already refunded",
+            "htlc_id": args.htlc_id,
+            "status": stored_htlc.state
+        });
+        println!("{}", serde_json::to_string_pretty(&output)?);
+        return Ok(());
+    }
+
+    // Parse the secret from hex string
+    let secret_bytes = match hex::decode(&args.secret) {
+        Ok(bytes) => bytes,
+        Err(_) => {
+            let output = json!({
+                "error": "Invalid secret format",
+                "message": "Secret must be a valid hex string"
+            });
+            println!("{}", serde_json::to_string_pretty(&output)?);
+            return Ok(());
+        }
+    };
+
+    // Convert to Secret type (32 bytes)
+    let secret: fusion_core::htlc::Secret = match secret_bytes.try_into() {
+        Ok(arr) => arr,
+        Err(_) => {
+            let output = json!({
+                "error": "Invalid secret length",
+                "message": "Secret must be exactly 32 bytes (64 hex characters)"
+            });
+            println!("{}", serde_json::to_string_pretty(&output)?);
+            return Ok(());
+        }
+    };
+
+    // Create a mutable HTLC to validate the claim
+    let mut htlc = Htlc::new(
+        stored_htlc.sender.clone(),
+        stored_htlc.recipient.clone(),
+        stored_htlc.amount,
+        stored_htlc.secret_hash,
+        stored_htlc.timeout,
+    )?;
+
+    // Try to claim with the provided secret
+    match htlc.claim(&secret) {
+        Ok(_) => {
+            // Update state in storage
+            STORAGE.update_state(&args.htlc_id, HtlcState::Claimed)?;
+            
+            // Output successful claim
+            let output = json!({
+                "htlc_id": args.htlc_id,
+                "status": "Claimed",
+                "claimed_at": chrono::Utc::now().to_rfc3339()
+            });
+            println!("{}", serde_json::to_string_pretty(&output)?);
+            Ok(())
+        }
+        Err(fusion_core::htlc::HtlcError::InvalidSecret) => {
+            let output = json!({
+                "error": "Invalid secret",
+                "htlc_id": args.htlc_id
+            });
+            println!("{}", serde_json::to_string_pretty(&output)?);
+            Ok(())
+        }
+        Err(e) => {
+            let output = json!({
+                "error": format!("Claim failed: {}", e),
+                "htlc_id": args.htlc_id
+            });
+            println!("{}", serde_json::to_string_pretty(&output)?);
+            Ok(())
+        }
+    }
 }
 
 async fn handle_refund(args: RefundArgs) -> Result<()> {

--- a/fusion-cli/tests/cli_tests.rs
+++ b/fusion-cli/tests/cli_tests.rs
@@ -1,0 +1,144 @@
+use assert_cmd::Command;
+use fusion_core::htlc::{generate_secret, hash_secret};
+use predicates::prelude::*;
+use serde_json::Value;
+
+#[test]
+fn test_claim_with_valid_secret() {
+    // First, create an HTLC
+    let mut cmd = Command::cargo_bin("fusion-cli").unwrap();
+    let create_output = cmd
+        .arg("create-htlc")
+        .arg("--sender")
+        .arg("Alice")
+        .arg("--recipient")
+        .arg("Bob")
+        .arg("--amount")
+        .arg("1000")
+        .arg("--timeout")
+        .arg("3600")
+        .output()
+        .expect("Failed to create HTLC");
+    
+    assert!(create_output.status.success());
+    
+    // Parse the output to get HTLC ID and secret
+    let output_json: Value = serde_json::from_slice(&create_output.stdout)
+        .expect("Failed to parse create output");
+    let htlc_id = output_json["htlc_id"].as_str().unwrap();
+    let secret = output_json["secret"].as_str().unwrap();
+    
+    // Now claim the HTLC
+    let mut claim_cmd = Command::cargo_bin("fusion-cli").unwrap();
+    claim_cmd
+        .arg("claim")
+        .arg("--htlc-id")
+        .arg(htlc_id)
+        .arg("--secret")
+        .arg(secret)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"status\": \"Claimed\""));
+}
+
+#[test]
+fn test_claim_with_invalid_secret() {
+    // First, create an HTLC
+    let mut cmd = Command::cargo_bin("fusion-cli").unwrap();
+    let create_output = cmd
+        .arg("create-htlc")
+        .arg("--sender")
+        .arg("Alice")
+        .arg("--recipient")
+        .arg("Bob")
+        .arg("--amount")
+        .arg("1000")
+        .arg("--timeout")
+        .arg("3600")
+        .output()
+        .expect("Failed to create HTLC");
+    
+    assert!(create_output.status.success());
+    
+    // Parse the output to get HTLC ID
+    let output_json: Value = serde_json::from_slice(&create_output.stdout)
+        .expect("Failed to parse create output");
+    let htlc_id = output_json["htlc_id"].as_str().unwrap();
+    
+    // Try to claim with wrong secret
+    let wrong_secret = hex::encode(generate_secret());
+    
+    let mut claim_cmd = Command::cargo_bin("fusion-cli").unwrap();
+    claim_cmd
+        .arg("claim")
+        .arg("--htlc-id")
+        .arg(htlc_id)
+        .arg("--secret")
+        .arg(&wrong_secret)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Invalid secret"));
+}
+
+#[test]
+fn test_claim_htlc_not_found() {
+    let mut cmd = Command::cargo_bin("fusion-cli").unwrap();
+    cmd
+        .arg("claim")
+        .arg("--htlc-id")
+        .arg("non_existent_htlc")
+        .arg("--secret")
+        .arg("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("HTLC not found"));
+}
+
+#[test]
+fn test_claim_already_claimed_htlc() {
+    // First, create an HTLC
+    let mut cmd = Command::cargo_bin("fusion-cli").unwrap();
+    let create_output = cmd
+        .arg("create-htlc")
+        .arg("--sender")
+        .arg("Alice")
+        .arg("--recipient")
+        .arg("Bob")
+        .arg("--amount")
+        .arg("1000")
+        .arg("--timeout")
+        .arg("3600")
+        .output()
+        .expect("Failed to create HTLC");
+    
+    assert!(create_output.status.success());
+    
+    // Parse the output to get HTLC ID and secret
+    let output_json: Value = serde_json::from_slice(&create_output.stdout)
+        .expect("Failed to parse create output");
+    let htlc_id = output_json["htlc_id"].as_str().unwrap();
+    let secret = output_json["secret"].as_str().unwrap();
+    
+    // First claim should succeed
+    let mut claim_cmd = Command::cargo_bin("fusion-cli").unwrap();
+    claim_cmd
+        .arg("claim")
+        .arg("--htlc-id")
+        .arg(htlc_id)
+        .arg("--secret")
+        .arg(secret)
+        .assert()
+        .success();
+    
+    // Second claim should fail
+    let mut claim_cmd2 = Command::cargo_bin("fusion-cli").unwrap();
+    claim_cmd2
+        .arg("claim")
+        .arg("--htlc-id")
+        .arg(htlc_id)
+        .arg("--secret")
+        .arg(secret)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("HTLC already claimed"));
+}


### PR DESCRIPTION
Closes #16

## 概要
HTLCをクレームするCLIコマンドを実装しました。

## 変更内容
- `fusion-cli claim` コマンドの実装
- HTLC IDとシークレットによるクレーム処理
- エラーハンドリング（無効なシークレット、HTLCが見つからない、既にクレーム済み）
- CLIコマンドのintegrationテストを追加
- 実装例をexamplesディレクトリに追加

Generated with [Claude Code](https://claude.ai/code)