### PR TITLE
feat: implement Limit Order CLI create command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ tracing-subscriber = "0.3"
 
 # Cryptographic dependencies
 sha2 = "0.10"
+sha3 = "0.10"
 hex = "0.4"
 rand = "0.8"
 secp256k1 = "0.27"

--- a/docs/limit-order-cli-guide.md
+++ b/docs/limit-order-cli-guide.md
@@ -1,0 +1,136 @@
+# Limit Order CLI Guide
+
+## Overview
+
+The `fusion-cli` tool provides commands to create and manage limit orders compatible with the 1inch Limit Order Protocol v3. This guide explains how to use the `order create` command to generate orders with embedded HTLC (Hash Time-Locked Contract) information.
+
+## Order Create Command
+
+The `order create` command generates a limit order with EIP-712 signature data.
+
+### Usage
+
+```bash
+fusion-cli order create [OPTIONS]
+```
+
+### Required Options
+
+- `--maker-asset <ADDRESS>` - The address of the asset the maker is offering
+- `--taker-asset <ADDRESS>` - The address of the asset the maker wants to receive
+- `--maker <ADDRESS>` - The address of the order creator (maker)
+- `--making-amount <AMOUNT>` - The amount of maker asset to trade
+- `--taking-amount <AMOUNT>` - The amount of taker asset to receive
+- `--htlc-secret-hash <HASH>` - The HTLC secret hash (32 bytes in hex format)
+- `--htlc-timeout <SECONDS>` - The HTLC timeout duration in seconds
+- `--chain-id <ID>` - The blockchain chain ID
+- `--verifying-contract <ADDRESS>` - The 1inch Limit Order Protocol contract address
+
+### Optional Options
+
+- `--receiver <ADDRESS>` - Custom receiver address (defaults to zero address)
+- `--allowed-sender <ADDRESS>` - Restrict who can fill the order (defaults to anyone)
+
+### Example
+
+```bash
+fusion-cli order create \
+  --maker-asset 0x4200000000000000000000000000000000000006 \
+  --taker-asset 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913 \
+  --maker 0x7aD8317e9aB4837AEF734e23d1C62F4938a6D950 \
+  --making-amount 1000000000000000000 \
+  --taking-amount 3000000000 \
+  --htlc-secret-hash 1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef \
+  --htlc-timeout 3600 \
+  --chain-id 84532 \
+  --verifying-contract 0x171C87724E720F2806fc29a010a62897B30fdb62
+```
+
+### Output Format
+
+The command outputs a JSON object containing:
+
+```json
+{
+  "order": {
+    "salt": "0x...",
+    "makerAsset": "0x4200000000000000000000000000000000000006",
+    "takerAsset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    "maker": "0x7aD8317e9aB4837AEF734e23d1C62F4938a6D950",
+    "receiver": "0x0000000000000000000000000000000000000000",
+    "allowedSender": "0x0000000000000000000000000000000000000000",
+    "makingAmount": "1000000000000000000",
+    "takingAmount": "3000000000",
+    "offsets": "0",
+    "interactions": "0x1234567890abcdef..."
+  },
+  "domain": {
+    "name": "1inch Limit Order Protocol",
+    "version": "3",
+    "chainId": 84532,
+    "verifyingContract": "0x171C87724E720F2806fc29a010a62897B30fdb62"
+  },
+  "eip712_hash": "0x...",
+  "htlc_info": {
+    "secret_hash": "0x1234567890abcdef...",
+    "timeout_seconds": 3600
+  }
+}
+```
+
+## HTLC Information Encoding
+
+The HTLC information is embedded in the order's `interactions` field (also referred to as `makerAssetData`):
+
+- **Bytes 0-31**: HTLC secret hash (32 bytes)
+- **Bytes 32-63**: HTLC timeout as uint256 (32 bytes, big-endian)
+
+This encoding allows the order to carry cross-chain swap information while remaining compatible with the 1inch protocol.
+
+## Signing the Order
+
+To create a valid order, you need to sign the `eip712_hash` with the maker's private key. This can be done using:
+
+1. **Web3 wallets** (MetaMask, etc.)
+2. **Ethers.js** or **Web3.js** libraries
+3. **Hardware wallets** (Ledger, Trezor)
+
+Example using ethers.js:
+
+```javascript
+const signature = await signer.signTypedData(
+  domain,
+  types,
+  order
+);
+```
+
+## Integration with 1inch Protocol
+
+Once signed, the order can be submitted to:
+
+1. **1inch Limit Order API** for public orderbook listing
+2. **Direct settlement** through the Limit Order Protocol contract
+3. **Cross-chain bridges** that support HTLC-based atomic swaps
+
+## Security Considerations
+
+1. **Secret Hash**: Never reveal the preimage until claiming funds
+2. **Timeout**: Set appropriate timeout values for cross-chain operations
+3. **Address Validation**: The CLI validates all addresses are properly formatted
+4. **Amount Precision**: Ensure correct decimal places for token amounts
+
+## Error Handling
+
+The CLI provides clear error messages for common issues:
+
+- Invalid address format
+- Incorrect secret hash length
+- Missing required parameters
+- Invalid hex encoding
+
+## Related Commands
+
+- `fusion-cli create-htlc` - Create HTLC contracts
+- `fusion-cli claim` - Claim HTLC with secret
+- `fusion-cli refund` - Refund expired HTLC

--- a/fusion-cli/src/main.rs
+++ b/fusion-cli/src/main.rs
@@ -5,6 +5,7 @@ use serde_json::json;
 use std::time::Duration;
 
 mod storage;
+mod order_handler;
 use once_cell::sync::Lazy;
 use storage::{HtlcStorage, StoredHtlc};
 
@@ -27,6 +28,20 @@ enum Commands {
     Claim(ClaimArgs),
     /// Refund an HTLC after timeout
     Refund(RefundArgs),
+    /// Order commands
+    Order(OrderCommands),
+}
+
+#[derive(Args)]
+struct OrderCommands {
+    #[command(subcommand)]
+    command: OrderSubcommands,
+}
+
+#[derive(Subcommand)]
+enum OrderSubcommands {
+    /// Create a new limit order
+    Create(order_handler::CreateOrderArgs),
 }
 
 #[derive(Args)]
@@ -70,6 +85,9 @@ async fn main() -> Result<()> {
         Commands::CreateHtlc(args) => handle_create_htlc(args).await,
         Commands::Claim(args) => handle_claim(args).await,
         Commands::Refund(args) => handle_refund(args).await,
+        Commands::Order(order_cmd) => match order_cmd.command {
+            OrderSubcommands::Create(args) => order_handler::handle_create_order(args).await,
+        },
     }
 }
 

--- a/fusion-cli/src/order_handler.rs
+++ b/fusion-cli/src/order_handler.rs
@@ -1,0 +1,219 @@
+use anyhow::{anyhow, Result};
+use clap::Args;
+use fusion_core::eip712::OrderEIP712;
+use fusion_core::order::{Order, OrderBuilder};
+use serde_json::json;
+
+#[derive(Args)]
+pub struct CreateOrderArgs {
+    /// Maker asset address
+    #[arg(long)]
+    pub maker_asset: String,
+    
+    /// Taker asset address
+    #[arg(long)]
+    pub taker_asset: String,
+    
+    /// Maker address
+    #[arg(long)]
+    pub maker: String,
+    
+    /// Making amount
+    #[arg(long)]
+    pub making_amount: u128,
+    
+    /// Taking amount
+    #[arg(long)]
+    pub taking_amount: u128,
+    
+    /// HTLC secret hash (32 bytes hex)
+    #[arg(long)]
+    pub htlc_secret_hash: String,
+    
+    /// HTLC timeout in seconds
+    #[arg(long)]
+    pub htlc_timeout: u64,
+    
+    /// Chain ID
+    #[arg(long)]
+    pub chain_id: u64,
+    
+    /// Verifying contract address
+    #[arg(long)]
+    pub verifying_contract: String,
+    
+    /// Receiver address (optional)
+    #[arg(long)]
+    pub receiver: Option<String>,
+    
+    /// Allowed sender address (optional)
+    #[arg(long)]
+    pub allowed_sender: Option<String>,
+}
+
+pub async fn handle_create_order(args: CreateOrderArgs) -> Result<()> {
+    // Validate addresses
+    validate_address(&args.maker_asset)?;
+    validate_address(&args.taker_asset)?;
+    validate_address(&args.maker)?;
+    validate_address(&args.verifying_contract)?;
+    
+    if let Some(ref receiver) = args.receiver {
+        validate_address(receiver)?;
+    }
+    
+    if let Some(ref allowed_sender) = args.allowed_sender {
+        validate_address(allowed_sender)?;
+    }
+    
+    // Parse HTLC secret hash
+    let secret_hash_bytes = hex::decode(args.htlc_secret_hash.trim_start_matches("0x"))
+        .map_err(|_| anyhow!("Invalid HTLC secret hash format"))?;
+    
+    if secret_hash_bytes.len() != 32 {
+        return Err(anyhow!("HTLC secret hash must be exactly 32 bytes"));
+    }
+    
+    // Create maker asset data with embedded HTLC info
+    let maker_asset_data = encode_htlc_data(&secret_hash_bytes, args.htlc_timeout);
+    
+    // Build order
+    let mut builder = OrderBuilder::new()
+        .maker_asset(&args.maker_asset)
+        .taker_asset(&args.taker_asset)
+        .maker(&args.maker)
+        .making_amount(args.making_amount)
+        .taking_amount(args.taking_amount)
+        .interactions(&maker_asset_data);
+    
+    if let Some(receiver) = args.receiver {
+        builder = builder.receiver(&receiver);
+    }
+    
+    if let Some(allowed_sender) = args.allowed_sender {
+        builder = builder.allowed_sender(&allowed_sender);
+    }
+    
+    let order = builder.build()?;
+    
+    // Create EIP-712 typed data
+    let typed_data = order.to_eip712(args.chain_id, &args.verifying_contract);
+    let eip712_hash = typed_data.hash();
+    
+    // Output result
+    let output = json!({
+        "order": {
+            "salt": format!("0x{}", hex::encode(&order.salt)),
+            "makerAsset": order.maker_asset,
+            "takerAsset": order.taker_asset,
+            "maker": order.maker,
+            "receiver": order.receiver,
+            "allowedSender": order.allowed_sender,
+            "makingAmount": order.making_amount.to_string(),
+            "takingAmount": order.taking_amount.to_string(),
+            "offsets": order.offsets.to_string(),
+            "interactions": order.interactions,
+        },
+        "domain": {
+            "name": typed_data.domain.name,
+            "version": typed_data.domain.version,
+            "chainId": typed_data.domain.chain_id,
+            "verifyingContract": typed_data.domain.verifying_contract,
+        },
+        "eip712_hash": format!("0x{}", hex::encode(eip712_hash)),
+        "htlc_info": {
+            "secret_hash": format!("0x{}", hex::encode(&secret_hash_bytes)),
+            "timeout_seconds": args.htlc_timeout,
+        }
+    });
+    
+    println!("{}", serde_json::to_string_pretty(&output)?);
+    Ok(())
+}
+
+fn validate_address(address: &str) -> Result<()> {
+    let addr = address.trim_start_matches("0x");
+    if addr.len() != 40 {
+        return Err(anyhow!("Invalid address: must be 40 hex characters (excluding 0x prefix)"));
+    }
+    
+    hex::decode(addr)
+        .map_err(|_| anyhow!("Invalid address: must be valid hexadecimal"))?;
+    
+    Ok(())
+}
+
+fn encode_htlc_data(secret_hash: &[u8], timeout: u64) -> String {
+    // Encode HTLC data into makerAssetData field
+    // Format: 32 bytes secret hash + 32 bytes timeout
+    let mut data = Vec::new();
+    data.extend_from_slice(secret_hash);
+    
+    // Encode timeout as 32 bytes
+    let mut timeout_bytes = [0u8; 32];
+    timeout_bytes[24..].copy_from_slice(&timeout.to_be_bytes());
+    data.extend_from_slice(&timeout_bytes);
+    
+    format!("0x{}", hex::encode(data))
+}
+
+pub fn extract_htlc_info(maker_asset_data: &str) -> Result<(Vec<u8>, u64)> {
+    let data = hex::decode(maker_asset_data.trim_start_matches("0x"))
+        .map_err(|_| anyhow!("Invalid maker asset data format"))?;
+    
+    if data.len() < 64 {
+        return Err(anyhow!("Maker asset data too short for HTLC info"));
+    }
+    
+    let secret_hash = data[0..32].to_vec();
+    let timeout_bytes = &data[32..64];
+    
+    // Extract timeout from last 8 bytes of the 32-byte field
+    let mut timeout_array = [0u8; 8];
+    timeout_array.copy_from_slice(&timeout_bytes[24..32]);
+    let timeout = u64::from_be_bytes(timeout_array);
+    
+    Ok((secret_hash, timeout))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[test]
+    fn test_htlc_info_extraction() {
+        let secret_hash = vec![0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef,
+                               0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef,
+                               0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef,
+                               0x12, 0x34, 0x56, 0x78, 0x90, 0xab, 0xcd, 0xef];
+        let timeout = 3600u64;
+        
+        // Create encoded data
+        let mut data = Vec::new();
+        data.extend_from_slice(&secret_hash);
+        
+        let mut timeout_bytes = [0u8; 32];
+        timeout_bytes[24..].copy_from_slice(&timeout.to_be_bytes());
+        data.extend_from_slice(&timeout_bytes);
+        
+        let encoded = format!("0x{}", hex::encode(&data));
+        
+        // Extract and verify
+        let (extracted_hash, extracted_timeout) = extract_htlc_info(&encoded).unwrap();
+        
+        assert_eq!(extracted_hash, secret_hash);
+        assert_eq!(extracted_timeout, timeout);
+    }
+    
+    #[test]
+    fn test_validate_address() {
+        // Valid addresses
+        assert!(validate_address("0x7aD8317e9aB4837AEF734e23d1C62F4938a6D950").is_ok());
+        assert!(validate_address("7aD8317e9aB4837AEF734e23d1C62F4938a6D950").is_ok());
+        
+        // Invalid addresses
+        assert!(validate_address("0x123").is_err());
+        assert!(validate_address("invalid_address").is_err());
+        assert!(validate_address("0xGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG").is_err());
+    }
+}

--- a/fusion-cli/tests/order_cli_tests.rs
+++ b/fusion-cli/tests/order_cli_tests.rs
@@ -1,0 +1,48 @@
+#[cfg(test)]
+mod order_cli_tests {
+    use assert_cmd::Command;
+    use predicates::prelude::*;
+
+    #[test]
+    fn test_order_create_command() {
+        let mut cmd = Command::cargo_bin("fusion-cli").unwrap();
+        
+        cmd.arg("order")
+            .arg("create")
+            .arg("--maker-asset").arg("0x4200000000000000000000000000000000000006")
+            .arg("--taker-asset").arg("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913")
+            .arg("--maker").arg("0x7aD8317e9aB4837AEF734e23d1C62F4938a6D950")
+            .arg("--making-amount").arg("1000000000000000000")
+            .arg("--taking-amount").arg("3000000000")
+            .arg("--htlc-secret-hash").arg("1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+            .arg("--htlc-timeout").arg("3600")
+            .arg("--chain-id").arg("84532")
+            .arg("--verifying-contract").arg("0x171C87724E720F2806fc29a010a62897B30fdb62");
+        
+        cmd.assert()
+            .success()
+            .stdout(predicate::str::contains("eip712_hash"))
+            .stdout(predicate::str::contains("order"))
+            .stdout(predicate::str::contains("domain"));
+    }
+
+    #[test]
+    fn test_order_create_with_invalid_address() {
+        let mut cmd = Command::cargo_bin("fusion-cli").unwrap();
+        
+        cmd.arg("order")
+            .arg("create")
+            .arg("--maker-asset").arg("invalid_address")
+            .arg("--taker-asset").arg("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913")
+            .arg("--maker").arg("0x7aD8317e9aB4837AEF734e23d1C62F4938a6D950")
+            .arg("--making-amount").arg("1000000000000000000")
+            .arg("--taking-amount").arg("3000000000")
+            .arg("--htlc-secret-hash").arg("1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+            .arg("--htlc-timeout").arg("3600")
+            .arg("--chain-id").arg("84532")
+            .arg("--verifying-contract").arg("0x171C87724E720F2806fc29a010a62897B30fdb62");
+        
+        cmd.assert()
+            .failure();
+    }
+}

--- a/fusion-core/Cargo.toml
+++ b/fusion-core/Cargo.toml
@@ -8,7 +8,9 @@ license.workspace = true
 [dependencies]
 thiserror.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 sha2.workspace = true
+sha3.workspace = true
 hex.workspace = true
 async-trait.workspace = true
 chrono = { version = "0.4", features = ["serde"] }

--- a/fusion-core/src/eip712.rs
+++ b/fusion-core/src/eip712.rs
@@ -1,0 +1,160 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use sha3::{Digest, Keccak256};
+
+use crate::order::Order;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EIP712Domain {
+    pub name: String,
+    pub version: String,
+    pub chain_id: u64,
+    pub verifying_contract: String,
+}
+
+impl EIP712Domain {
+    pub fn separator(&self) -> [u8; 32] {
+        let type_hash = keccak256(b"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+        
+        let mut hasher = Keccak256::new();
+        hasher.update(type_hash);
+        hasher.update(keccak256(self.name.as_bytes()));
+        hasher.update(keccak256(self.version.as_bytes()));
+        hasher.update(encode_uint256(self.chain_id));
+        hasher.update(encode_address(&self.verifying_contract));
+        
+        let result = hasher.finalize();
+        let mut separator = [0u8; 32];
+        separator.copy_from_slice(&result);
+        separator
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TypedData {
+    pub domain: EIP712Domain,
+    pub primary_type: String,
+    pub message: serde_json::Value,
+}
+
+impl TypedData {
+    pub fn hash(&self) -> [u8; 32] {
+        let domain_separator = self.domain.separator();
+        let message_hash = hash_struct(&self.primary_type, &self.message);
+        
+        let mut hasher = Keccak256::new();
+        hasher.update(b"\x19\x01");
+        hasher.update(domain_separator);
+        hasher.update(message_hash);
+        
+        let result = hasher.finalize();
+        let mut hash = [0u8; 32];
+        hash.copy_from_slice(&result);
+        hash
+    }
+}
+
+pub trait OrderEIP712 {
+    fn to_eip712(&self, chain_id: u64, verifying_contract: &str) -> TypedData;
+}
+
+impl OrderEIP712 for Order {
+    fn to_eip712(&self, chain_id: u64, verifying_contract: &str) -> TypedData {
+        let domain = EIP712Domain {
+            name: "1inch Limit Order Protocol".to_string(),
+            version: "3".to_string(),
+            chain_id,
+            verifying_contract: verifying_contract.to_string(),
+        };
+
+        let message = serde_json::json!({
+            "salt": format!("0x{}", hex::encode(&self.salt)),
+            "makerAsset": self.maker_asset,
+            "takerAsset": self.taker_asset,
+            "maker": self.maker,
+            "receiver": self.receiver,
+            "allowedSender": self.allowed_sender,
+            "makingAmount": self.making_amount.to_string(),
+            "takingAmount": self.taking_amount.to_string(),
+            "offsets": self.offsets.to_string(),
+            "interactions": self.interactions,
+        });
+
+        TypedData {
+            domain,
+            primary_type: "Order".to_string(),
+            message,
+        }
+    }
+}
+
+fn keccak256(data: &[u8]) -> [u8; 32] {
+    let mut hasher = Keccak256::new();
+    hasher.update(data);
+    let result = hasher.finalize();
+    let mut hash = [0u8; 32];
+    hash.copy_from_slice(&result);
+    hash
+}
+
+fn encode_uint256(value: u64) -> [u8; 32] {
+    let mut encoded = [0u8; 32];
+    encoded[24..].copy_from_slice(&value.to_be_bytes());
+    encoded
+}
+
+fn encode_address(address: &str) -> [u8; 32] {
+    let mut encoded = [0u8; 32];
+    let address_bytes = hex::decode(address.trim_start_matches("0x"))
+        .unwrap_or_else(|_| vec![0u8; 20]);
+    encoded[12..].copy_from_slice(&address_bytes[..20.min(address_bytes.len())]);
+    encoded
+}
+
+fn hash_struct(type_name: &str, message: &serde_json::Value) -> [u8; 32] {
+    // Simplified implementation for Order type
+    if type_name == "Order" {
+        let type_hash = keccak256(b"Order(uint256 salt,address makerAsset,address takerAsset,address maker,address receiver,address allowedSender,uint256 makingAmount,uint256 takingAmount,uint256 offsets,bytes interactions)");
+        
+        let mut hasher = Keccak256::new();
+        hasher.update(type_hash);
+        
+        // Hash each field according to its type
+        if let Some(salt) = message.get("salt").and_then(|v| v.as_str()) {
+            let salt_bytes = hex::decode(salt.trim_start_matches("0x")).unwrap_or([0u8; 32].to_vec());
+            let mut salt_array = [0u8; 32];
+            salt_array.copy_from_slice(&salt_bytes[..32.min(salt_bytes.len())]);
+            hasher.update(salt_array);
+        }
+        
+        // Address fields
+        for field in ["makerAsset", "takerAsset", "maker", "receiver", "allowedSender"] {
+            if let Some(addr) = message.get(field).and_then(|v| v.as_str()) {
+                hasher.update(encode_address(addr));
+            }
+        }
+        
+        // Amount fields
+        for field in ["makingAmount", "takingAmount", "offsets"] {
+            if let Some(amount_str) = message.get(field).and_then(|v| v.as_str()) {
+                let amount = amount_str.parse::<u128>().unwrap_or(0);
+                let mut encoded = [0u8; 32];
+                encoded[16..].copy_from_slice(&amount.to_be_bytes());
+                hasher.update(encoded);
+            }
+        }
+        
+        // Interactions (bytes)
+        if let Some(interactions) = message.get("interactions").and_then(|v| v.as_str()) {
+            let bytes = hex::decode(interactions.trim_start_matches("0x")).unwrap_or_default();
+            hasher.update(keccak256(&bytes));
+        }
+        
+        let result = hasher.finalize();
+        let mut hash = [0u8; 32];
+        hash.copy_from_slice(&result);
+        hash
+    } else {
+        [0u8; 32]
+    }
+}

--- a/fusion-core/src/lib.rs
+++ b/fusion-core/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod chains;
 pub mod config;
 pub mod htlc;
+pub mod order;
+pub mod eip712;

--- a/fusion-core/src/order.rs
+++ b/fusion-core/src/order.rs
@@ -1,0 +1,143 @@
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Order {
+    pub salt: [u8; 32],
+    pub maker_asset: String,
+    pub taker_asset: String,
+    pub maker: String,
+    pub receiver: String,
+    pub allowed_sender: String,
+    pub making_amount: u128,
+    pub taking_amount: u128,
+    pub offsets: u256,
+    pub interactions: String,
+}
+
+type u256 = u64; // Simplified for now
+
+impl Order {
+    pub fn maker_asset(&self) -> &str {
+        &self.maker_asset
+    }
+
+    pub fn taker_asset(&self) -> &str {
+        &self.taker_asset
+    }
+
+    pub fn maker(&self) -> &str {
+        &self.maker
+    }
+
+    pub fn making_amount(&self) -> u128 {
+        self.making_amount
+    }
+
+    pub fn taking_amount(&self) -> u128 {
+        self.taking_amount
+    }
+}
+
+pub struct OrderBuilder {
+    salt: Option<[u8; 32]>,
+    maker_asset: Option<String>,
+    taker_asset: Option<String>,
+    maker: Option<String>,
+    receiver: Option<String>,
+    allowed_sender: Option<String>,
+    making_amount: Option<u128>,
+    taking_amount: Option<u128>,
+    offsets: Option<u256>,
+    interactions: Option<String>,
+}
+
+impl OrderBuilder {
+    pub fn new() -> Self {
+        Self {
+            salt: None,
+            maker_asset: None,
+            taker_asset: None,
+            maker: None,
+            receiver: None,
+            allowed_sender: None,
+            making_amount: None,
+            taking_amount: None,
+            offsets: None,
+            interactions: None,
+        }
+    }
+
+    pub fn salt(mut self, salt: [u8; 32]) -> Self {
+        self.salt = Some(salt);
+        self
+    }
+
+    pub fn maker_asset(mut self, maker_asset: &str) -> Self {
+        self.maker_asset = Some(maker_asset.to_string());
+        self
+    }
+
+    pub fn taker_asset(mut self, taker_asset: &str) -> Self {
+        self.taker_asset = Some(taker_asset.to_string());
+        self
+    }
+
+    pub fn maker(mut self, maker: &str) -> Self {
+        self.maker = Some(maker.to_string());
+        self
+    }
+
+    pub fn receiver(mut self, receiver: &str) -> Self {
+        self.receiver = Some(receiver.to_string());
+        self
+    }
+
+    pub fn allowed_sender(mut self, allowed_sender: &str) -> Self {
+        self.allowed_sender = Some(allowed_sender.to_string());
+        self
+    }
+
+    pub fn making_amount(mut self, amount: u128) -> Self {
+        self.making_amount = Some(amount);
+        self
+    }
+
+    pub fn taking_amount(mut self, amount: u128) -> Self {
+        self.taking_amount = Some(amount);
+        self
+    }
+
+    pub fn offsets(mut self, offsets: u256) -> Self {
+        self.offsets = Some(offsets);
+        self
+    }
+
+    pub fn interactions(mut self, interactions: &str) -> Self {
+        self.interactions = Some(interactions.to_string());
+        self
+    }
+
+    pub fn build(self) -> Result<Order> {
+        // Generate random salt if not provided
+        let salt = self.salt.unwrap_or_else(|| {
+            let mut salt = [0u8; 32];
+            use rand::Rng;
+            rand::thread_rng().fill(&mut salt);
+            salt
+        });
+
+        Ok(Order {
+            salt,
+            maker_asset: self.maker_asset.ok_or_else(|| anyhow!("maker_asset is required"))?,
+            taker_asset: self.taker_asset.ok_or_else(|| anyhow!("taker_asset is required"))?,
+            maker: self.maker.ok_or_else(|| anyhow!("maker is required"))?,
+            receiver: self.receiver.unwrap_or_else(|| "0x0000000000000000000000000000000000000000".to_string()),
+            allowed_sender: self.allowed_sender.unwrap_or_else(|| "0x0000000000000000000000000000000000000000".to_string()),
+            making_amount: self.making_amount.ok_or_else(|| anyhow!("making_amount is required"))?,
+            taking_amount: self.taking_amount.ok_or_else(|| anyhow!("taking_amount is required"))?,
+            offsets: self.offsets.unwrap_or(0),
+            interactions: self.interactions.unwrap_or_else(|| "0x".to_string()),
+        })
+    }
+}

--- a/fusion-core/tests/eip712_tests.rs
+++ b/fusion-core/tests/eip712_tests.rs
@@ -1,0 +1,39 @@
+#[cfg(test)]
+mod eip712_tests {
+    use fusion_core::eip712::{EIP712Domain, OrderEIP712, TypedData};
+    use fusion_core::order::Order;
+
+    #[test]
+    fn test_eip712_domain_separator() {
+        let domain = EIP712Domain {
+            name: "1inch Limit Order Protocol".to_string(),
+            version: "3".to_string(),
+            chain_id: 84532,
+            verifying_contract: "0x171C87724E720F2806fc29a010a62897B30fdb62".to_string(),
+        };
+
+        let separator = domain.separator();
+        assert_eq!(separator.len(), 32);
+    }
+
+    #[test]
+    fn test_order_eip712_hash() {
+        let order = Order {
+            salt: [1u8; 32],
+            maker_asset: "0x4200000000000000000000000000000000000006".to_string(),
+            taker_asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913".to_string(),
+            maker: "0x7aD8317e9aB4837AEF734e23d1C62F4938a6D950".to_string(),
+            receiver: "0x0000000000000000000000000000000000000000".to_string(),
+            allowed_sender: "0x0000000000000000000000000000000000000000".to_string(),
+            making_amount: 1000000000000000000u128,
+            taking_amount: 3000000000u128,
+            offsets: 0,
+            interactions: "0x".to_string(),
+        };
+
+        let typed_data = order.to_eip712(84532, "0x171C87724E720F2806fc29a010a62897B30fdb62");
+        let hash = typed_data.hash();
+        
+        assert_eq!(hash.len(), 32);
+    }
+}

--- a/fusion-core/tests/order_tests.rs
+++ b/fusion-core/tests/order_tests.rs
@@ -1,0 +1,22 @@
+#[cfg(test)]
+mod order_tests {
+    use fusion_core::order::{Order, OrderBuilder};
+
+    #[test]
+    fn test_create_order() {
+        let order = OrderBuilder::new()
+            .maker_asset("0x4200000000000000000000000000000000000006")
+            .taker_asset("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913")
+            .maker("0x7aD8317e9aB4837AEF734e23d1C62F4938a6D950")
+            .making_amount(1000000000000000000u128)
+            .taking_amount(3000000000u128)
+            .build()
+            .expect("Failed to build order");
+
+        assert_eq!(order.maker_asset(), "0x4200000000000000000000000000000000000006");
+        assert_eq!(order.taker_asset(), "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
+        assert_eq!(order.maker(), "0x7aD8317e9aB4837AEF734e23d1C62F4938a6D950");
+        assert_eq!(order.making_amount(), 1000000000000000000u128);
+        assert_eq!(order.taking_amount(), 3000000000u128);
+    }
+}


### PR DESCRIPTION
## 概要
1inch Limit Order Protocolと連携するCLIコマンドの実装

## 変更内容
- Order構造体とEIP-712署名の実装
- `fusion-cli order create`コマンドの追加
- makerAssetDataへのHTLC情報埋め込み
- テストとドキュメントの作成

Closes #40

Generated with [Claude Code](https://claude.ai/code)