### PR TITLE
add image

### DIFF
--- a/cover-image.svg
+++ b/cover-image.svg
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="640" height="360" viewBox="0 0 640 360" xmlns="http://www.w3.org/2000/svg">
+    <!-- Background gradient -->
+    <defs>
+        <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" style="stop-color:#1a1a2e;stop-opacity:1" />
+            <stop offset="100%" style="stop-color:#16213e;stop-opacity:1" />
+        </linearGradient>
+
+        <linearGradient id="ethGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" style="stop-color:#627EEA;stop-opacity:1" />
+            <stop offset="100%" style="stop-color:#4C68D7;stop-opacity:1" />
+        </linearGradient>
+
+        <linearGradient id="nearGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" style="stop-color:#00C08B;stop-opacity:1" />
+            <stop offset="100%" style="stop-color:#00A170;stop-opacity:1" />
+        </linearGradient>
+
+        <!-- Pattern for background -->
+        <pattern id="gridPattern" x="0" y="0" width="50" height="50" patternUnits="userSpaceOnUse">
+            <line x1="0" y1="0" x2="50" y2="50" stroke="rgba(255,255,255,0.05)" stroke-width="0.5"/>
+            <line x1="50" y1="0" x2="0" y2="50" stroke="rgba(255,255,255,0.05)" stroke-width="0.5"/>
+        </pattern>
+    </defs>
+
+    <!-- Background -->
+    <rect width="640" height="360" fill="url(#bgGradient)"/>
+    <rect width="640" height="360" fill="url(#gridPattern)"/>
+
+    <!-- Decorative circles -->
+    <circle cx="580" cy="60" r="80" fill="#627EEA" opacity="0.1"/>
+    <circle cx="60" cy="300" r="60" fill="#00C08B" opacity="0.1"/>
+
+    <!-- Logo section -->
+    <g transform="translate(320, 100)">
+        <!-- Ethereum logo -->
+        <rect x="-150" y="-30" width="60" height="60" rx="12" fill="url(#ethGradient)"/>
+        <text x="-120" y="10" font-family="Arial, sans-serif" font-size="24" font-weight="bold" fill="white" text-anchor="middle">ETH</text>
+
+        <!-- Swap arrow -->
+        <text x="0" y="10" font-family="Arial, sans-serif" font-size="36" fill="#FFD700" text-anchor="middle">⇄</text>
+
+        <!-- NEAR logo -->
+        <rect x="90" y="-30" width="60" height="60" rx="12" fill="url(#nearGradient)"/>
+        <text x="120" y="10" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">NEAR</text>
+    </g>
+
+    <!-- Main title -->
+    <text x="320" y="200" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif" font-size="56" font-weight="800" fill="white" text-anchor="middle">UniteSwap</text>
+
+    <!-- Subtitle -->
+    <text x="320" y="240" font-family="Arial, sans-serif" font-size="20" fill="#B8BCC8" text-anchor="middle">
+        First <tspan fill="#FFD700" font-weight="700">EVM ↔ NEAR</tspan> Atomic Swap Bridge
+    </text>
+
+    <!-- Tech badges -->
+    <g transform="translate(320, 280)">
+        <!-- 1inch Fusion+ badge -->
+        <rect x="-180" y="-15" width="110" height="30" rx="15" fill="rgba(255,255,255,0.1)" stroke="rgba(255,255,255,0.2)"/>
+        <text x="-125" y="5" font-family="Arial, sans-serif" font-size="14" fill="white" text-anchor="middle">1inch Fusion+</text>
+
+        <!-- HTLC badge -->
+        <rect x="-55" y="-15" width="50" height="30" rx="15" fill="rgba(255,255,255,0.1)" stroke="rgba(255,255,255,0.2)"/>
+        <text x="-30" y="5" font-family="Arial, sans-serif" font-size="14" fill="white" text-anchor="middle">HTLC</text>
+
+        <!-- Rust CLI badge -->
+        <rect x="15" y="-15" width="70" height="30" rx="15" fill="rgba(255,255,255,0.1)" stroke="rgba(255,255,255,0.2)"/>
+        <text x="50" y="5" font-family="Arial, sans-serif" font-size="14" fill="white" text-anchor="middle">Rust CLI</text>
+    </g>
+
+    <!-- Footer -->
+    <text x="320" y="340" font-family="Arial, sans-serif" font-size="12" fill="#666666" text-anchor="middle">ETHGlobal Unite Defi Hackathon</text>
+</svg>

--- a/logo-icon-512.svg
+++ b/logo-icon-512.svg
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+    <!-- Background gradient -->
+    <defs>
+        <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" style="stop-color:#1a1a2e;stop-opacity:1" />
+            <stop offset="100%" style="stop-color:#16213e;stop-opacity:1" />
+        </linearGradient>
+        
+        <linearGradient id="ethGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" style="stop-color:#627EEA;stop-opacity:1" />
+            <stop offset="100%" style="stop-color:#4C68D7;stop-opacity:1" />
+        </linearGradient>
+        
+        <linearGradient id="nearGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" style="stop-color:#00C08B;stop-opacity:1" />
+            <stop offset="100%" style="stop-color:#00A170;stop-opacity:1" />
+        </linearGradient>
+        
+        <linearGradient id="swapGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" style="stop-color:#FFD700;stop-opacity:1" />
+            <stop offset="100%" style="stop-color:#FFA500;stop-opacity:1" />
+        </linearGradient>
+        
+        <!-- Drop shadow filter -->
+        <filter id="dropShadow">
+            <feDropShadow dx="0" dy="4" stdDeviation="8" flood-opacity="0.3"/>
+        </filter>
+    </defs>
+    
+    <!-- Background circle -->
+    <circle cx="256" cy="256" r="256" fill="url(#bgGradient)"/>
+    
+    <!-- Background pattern -->
+    <g opacity="0.1">
+        <circle cx="256" cy="256" r="200" fill="none" stroke="white" stroke-width="1"/>
+        <circle cx="256" cy="256" r="150" fill="none" stroke="white" stroke-width="1"/>
+        <circle cx="256" cy="256" r="100" fill="none" stroke="white" stroke-width="1"/>
+    </g>
+    
+    <!-- Main logo group -->
+    <g transform="translate(256, 256)">
+        <!-- Ethereum circle -->
+        <g transform="translate(-120, -40)">
+            <circle cx="0" cy="0" r="70" fill="url(#ethGradient)" filter="url(#dropShadow)"/>
+            <text x="0" y="10" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle">ETH</text>
+        </g>
+        
+        <!-- NEAR circle -->
+        <g transform="translate(120, -40)">
+            <circle cx="0" cy="0" r="70" fill="url(#nearGradient)" filter="url(#dropShadow)"/>
+            <text x="0" y="10" font-family="Arial, sans-serif" font-size="32" font-weight="bold" fill="white" text-anchor="middle">NEAR</text>
+        </g>
+        
+        <!-- Swap arrows in the center -->
+        <g transform="translate(0, -40)">
+            <!-- Arrow pointing right -->
+            <path d="M -40 -20 L 20 -20 L 20 -30 L 40 -10 L 20 0 L 20 -10 L -40 -10 Z" 
+                  fill="url(#swapGradient)" opacity="0.9"/>
+            <!-- Arrow pointing left -->
+            <path d="M 40 20 L -20 20 L -20 10 L -40 30 L -20 40 L -20 30 L 40 30 Z" 
+                  fill="url(#swapGradient)" opacity="0.9"/>
+        </g>
+        
+        <!-- UniteSwap text -->
+        <text x="0" y="100" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif" 
+              font-size="48" font-weight="800" fill="white" text-anchor="middle">UniteSwap</text>
+    </g>
+    
+    <!-- Decorative elements -->
+    <circle cx="100" cy="100" r="30" fill="#627EEA" opacity="0.1"/>
+    <circle cx="412" cy="412" r="25" fill="#00C08B" opacity="0.1"/>
+</svg>


### PR DESCRIPTION
## 概要

プロジェクトのブランド強化・審査/提出資料・デモ用にSVG形式のカバー画像（cover-image.svg）およびロゴアイコン（logo-icon-512.svg）を新規追加しました。今後のREADME・デッキ・デモ・ウェブサイト・提出物等で活用できます。

## 変更内容

- `cover-image.svg`
  - プロジェクトの表紙・プレゼン・SNS等で使える汎用的カバー画像を追加
- `logo-icon-512.svg`
  - アプリ・ウェブ・デモ・デッキ用の高解像度ロゴアイコンを追加

## 背景

ETHGlobal Unite提出・デモ・審査、今後のプロダクト展開に向けて、統一感あるビジュアルアイデンティティを確立するための画像素材を整備しました。READMEやピッチデック、Webサイトなどでの活用が想定されています。

## 確認してほしい点

- 画像ファイルがSVG形式で正しく追加されていること
- ブランドイメージ・用途に合致しているか
- 他の資料（README, デッキ等）での利用方法